### PR TITLE
Convert absolute into relative paths

### DIFF
--- a/src/playground.gleam
+++ b/src/playground.gleam
@@ -279,16 +279,16 @@ fn file_error(
 
 // Shared stylesheets paths
 
-const css__gleam_common = "/common.css"
+const css__gleam_common = "common.css"
 
 /// Loads fonts and defines font sizes
-const css_fonts = "/css/fonts.css"
+const css_fonts = "css/fonts.css"
 
 /// Derives app colors for both dark & light themes from common.css variables
-const css_theme = "/css/theme.css"
+const css_theme = "css/theme.css"
 
 /// Defines layout unit variables
-const css_layout = "/css/layout.css"
+const css_layout = "css/layout.css"
 
 /// Sensitive defaults for any page
 const css_defaults_page = [css_fonts, css_theme, css__gleam_common, css_layout]
@@ -296,20 +296,20 @@ const css_defaults_page = [css_fonts, css_theme, css__gleam_common, css_layout]
 // Page stylesheet paths
 
 /// Common stylesheet for all playground pages
-const css_root = "/css/root.css"
+const css_root = "css/root.css"
 
 // Path to the css speciic to to lesson & main pages
-const css_playground_page = "/css/pages/playground.css"
+const css_playground_page = "css/pages/playground.css"
 
 // Defines code syntax highlighting for highlightJS & CodeFlash
 // based on dark / light mode and the currenly loaded color scheme
-const css_syntax_highlight = "/css/code/syntax-highlight.css"
+const css_syntax_highlight = "css/code/syntax-highlight.css"
 
 // Color schemes
 // TODO: add more color schemes
 
 /// Atom One Dark & Atom One Light colors
-const css_scheme_atom_one = "/css/code/color-schemes/atom-one.css"
+const css_scheme_atom_one = "css/code/color-schemes/atom-one.css"
 
 /// Sensitive defaults for any page needing to display Gleam code
 /// To be used alonside defaults_page
@@ -372,7 +372,7 @@ fn home_page(gleam_version: String) -> Html {
     h("script", [#("type", "gleam"), #("id", "code")], [
       htmb.dangerous_unescaped_fragment(string_builder.from_string(hello_joe)),
     ]),
-    html_script("/index.js", ScriptOptions(module: True, defer: False), []),
+    html_script("index.js", ScriptOptions(module: True, defer: False), []),
   ]
 
   let body_content = [

--- a/src/playground/widgets.gleam
+++ b/src/playground/widgets.gleam
@@ -186,7 +186,7 @@ pub fn text_link(
 /// Renders the playground's navbar as html
 pub fn navbar(gleam_version: String) -> Html {
   h("nav", [#("class", "navbar")], [
-    anchor("/", [#("class", "logo")], [
+    anchor("", [#("class", "logo")], [
       h(
         "img",
         [

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -1,7 +1,7 @@
 let compiler;
 
 export default async function initGleamCompiler() {
-  const wasm = await import("compiler/gleam_wasm.js");
+  const wasm = await import("./compiler/gleam_wasm.js");
   await wasm.default();
   wasm.initialise_panic_hook();
   if (!compiler) {

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -1,7 +1,7 @@
 let compiler;
 
 export default async function initGleamCompiler() {
-  const wasm = await import("/compiler/gleam_wasm.js");
+  const wasm = await import("compiler/gleam_wasm.js");
   await wasm.default();
   wasm.initialise_panic_hook();
   if (!compiler) {

--- a/static/index.js
+++ b/static/index.js
@@ -95,7 +95,7 @@ function debounce(fn, delay) {
 // this first time it is as the worker is initialising.
 let workerWorking = true;
 let queuedWork = undefined;
-const worker = new Worker("/worker.js", { type: "module" });
+const worker = new Worker("worker.js", { type: "module" });
 
 function sendToWorker(code) {
   if (workerWorking) {

--- a/static/worker.js
+++ b/static/worker.js
@@ -17,8 +17,10 @@ console.log = (...args) => {
 };
 
 async function loadProgram(js) {
+  // URL to worker.js ('base/worker.js')
   const url = new URL(import.meta.url);
-  url.pathname = "";
+  // Remove 'worker.js', keep just 'base/'
+  url.pathname = url.pathname.substring(0, url.pathname.lastIndexOf("/") + 1);
   url.hash = "";
   url.search = "";
   const href = url.toString();


### PR DESCRIPTION
Removes all URLs of the form "/css/...", "/index.js", etc., replacing them with "css/...", "index.js".

Without this fix, we can't host the playground in subpaths. For example, hosting it at `https://gleam.run/playground` would have the website try to access `https://gleam.run/index.js`, `https://gleam.run/css/theme.css` and so on, rather than `https://gleam.run/playground/index.js` and `https://gleam.run/playground/css/theme.css`. That is, links aren't respecting the base.

This is particularly annoying while testing locally, as the playground might be in a folder. However, this fix is also required for my use case: I'm hosting my customized playground on [GitHub Pages](https://glistix.github.io/playground/), which uses the repository name. Regardless, I believe having the website respect its base is nice and flexible, not to mention that lots of existing path constants were already used in a relative way (such as `const prelude` in `playground.gleam`).

The only assumption I make here is that files in `static` are exported to the same folder where `index.html` is, as well as `precompiled/`, which is indeed the case.

I've tested this PR locally with `python3 -m http.server` on a parent directory (i.e. the playground is available at `localhost:8000/public`) and all seems to work.