### PR TITLE
Fixes

### DIFF
--- a/static/css/pages/playground.css
+++ b/static/css/pages/playground.css
@@ -14,6 +14,7 @@
   border: var(--color-divider);
   flex-grow: 1;
   min-height: 100%;
+  width: 100%;
 }
 
 #playground-content {

--- a/static/worker.js
+++ b/static/worker.js
@@ -46,14 +46,11 @@ async function compileEval(code) {
   try {
     project.writeModule("main", code);
     project.compilePackage("javascript");
-    const js = project.readCompiledJavaScript("main");
+    result.js = project.readCompiledJavaScript("main");
     project.compilePackage("erlang");
-    const erlang = project.readCompiledErlang("main");
-    const main = await loadProgram(js);
+    result.erlang = project.readCompiledErlang("main");
+    const main = await loadProgram(result.js);
     if (main) main();
-
-    result.js = js;
-    result.erlang = erlang;
   } catch (error) {
     console.error(error);
     result.error = error.toString();


### PR DESCRIPTION
- Fix a rendering bug when long text that cannot wrap is printed by the gleam code
- Fix not seeing the erlang and JS output when a runtime error is caused by running the JS

To reproduce the rendering bug, run the following gleam code in the playground:

```gleam
import gleam/io
import gleam/string

pub fn main() {
  io.println(string.repeat("abc", 2000))
}
```

To reproduce not showing the erlang and JS, run the following code in the playground:

```gleam
pub fn main() {
  panic
}
```